### PR TITLE
fix repository link in SonarCloud

### DIFF
--- a/sonar.sh
+++ b/sonar.sh
@@ -1,1 +1,1 @@
-mvn verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=ufba-poo-2022-1_equipe9 -Dmaven.test.skip=true -Dsonar.organization=ufba-poo-2022-1 -Dsonar.host.url=https://sonarcloud.io
+mvn verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=ufba-poo-2022-1_equipe19 -Dmaven.test.skip=true -Dsonar.organization=ufba-poo-2022-1 -Dsonar.host.url=https://sonarcloud.io


### PR DESCRIPTION
Estou solicitando esta correção, pois o `sonar.sh` da equipe 19 está apontando para o link do Sonar Cloud da equipe 9. Com isso, nós (equipe 9) não estamos conseguindo ver as nossas métricas.